### PR TITLE
feat: save asset on exit

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,9 +5,30 @@ import Header from 'src/components/Header';
 import Preview from 'src/components/Preview';
 import Form from 'src/components/Form';
 import Footer from 'src/components/Footer';
+import { useEffect } from 'react';
 
 function App() {
-    const [asset, updateAsset] = useImmer(placeholderAsset);
+    const [asset, updateAsset] = useImmer(loadFromLocalStorage());
+
+    function loadFromLocalStorage() {
+        const currentAsset = localStorage.getItem('currentAsset');
+        if (currentAsset) {
+            return JSON.parse(currentAsset);
+        }
+        return placeholderAsset;
+    }
+
+    useEffect(() => {
+        function saveToLocalStorage() {
+            localStorage.setItem('currentAsset', JSON.stringify(asset));
+        }
+
+        window.addEventListener('beforeunload', saveToLocalStorage);
+
+        return () => {
+            window.removeEventListener('beforeunload', saveToLocalStorage);
+        };
+    }, [asset]);
 
     return (
         <div className="wrapper">


### PR DESCRIPTION
- When the user closes the tab or their browser, the current asset state is now saved to localStorage.
- Upon opening the app, the workbench checks if an asset already exists in localStorage. If yes, it loads that one, otherwise it loads the placeholder.